### PR TITLE
DI viewModels, fix empty login field crash

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -20,8 +20,8 @@ android {
         applicationId "com.example.internapp"
         minSdkVersion 24
         targetSdkVersion 30
-        versionCode 1
-        versionName "1.0"
+        versionCode 2
+        versionName "1.0.1"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/com/example/internapp/authentication/LoginFragment.kt
+++ b/app/src/main/java/com/example/internapp/authentication/LoginFragment.kt
@@ -1,10 +1,12 @@
 package com.example.internapp.authentication
 
+import android.content.Context
 import android.os.Bundle
 import androidx.fragment.app.Fragment
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.view.inputmethod.InputMethodManager
 import androidx.activity.OnBackPressedCallback
 import androidx.fragment.app.activityViewModels
 import androidx.navigation.fragment.findNavController
@@ -12,7 +14,9 @@ import com.example.internapp.R
 import com.example.internapp.databinding.LoginFragmentBinding
 import com.example.internapp.repository.UIState
 import com.google.android.material.snackbar.Snackbar
+import dagger.hilt.android.AndroidEntryPoint
 
+@AndroidEntryPoint
 class LoginFragment : Fragment() {
     private val viewModel: AuthenticationViewModel by activityViewModels()
     private lateinit var binding: LoginFragmentBinding
@@ -24,11 +28,14 @@ class LoginFragment : Fragment() {
         binding = LoginFragmentBinding.inflate(inflater, container, false)
 
         binding.btnLogin.setOnClickListener {
+            val imm = activity?.getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager
+            imm.hideSoftInputFromWindow(requireView().windowToken, 0)
             authenticateUser()
         }
         binding.btnToRegistration.setOnClickListener {
             findNavController().navigate(LoginFragmentDirections.actionLoginFragmentToRegistrationFragment())
         }
+        viewModel.setUIState(UIState.OnWaiting)
         initStateObserver()
         overrideBackButton()
         return binding.root
@@ -57,7 +64,23 @@ class LoginFragment : Fragment() {
         val email = binding.tietLogin.text?.trim().toString()
         val password = binding.tietPassword.text?.trim().toString()
 
-        viewModel.authenticateUser(email, password)
+        if (email.isEmpty()) {
+            Snackbar.make(
+                requireView(),
+                resources.getString(R.string.noEmail),
+                Snackbar.LENGTH_SHORT
+            ).show()
+        } else {
+            if (password.isEmpty()) {
+                Snackbar.make(
+                    requireView(),
+                    resources.getString(R.string.noPassword),
+                    Snackbar.LENGTH_SHORT
+                ).show()
+            } else {
+                viewModel.authenticateUser(email, password)
+            }
+        }
     }
 
     private fun initStateObserver() {
@@ -70,6 +93,9 @@ class LoginFragment : Fragment() {
                 }
                 UIState.InProgress -> {
                     binding.pbLogin.visibility = View.VISIBLE
+                }
+                UIState.OnWaiting -> {
+                    binding.pbLogin.visibility = View.GONE
                 }
                 UIState.OnError -> {
                     binding.pbLogin.visibility = View.GONE

--- a/app/src/main/java/com/example/internapp/authentication/LoginFragment.kt
+++ b/app/src/main/java/com/example/internapp/authentication/LoginFragment.kt
@@ -28,8 +28,8 @@ class LoginFragment : Fragment() {
         binding = LoginFragmentBinding.inflate(inflater, container, false)
 
         binding.btnLogin.setOnClickListener {
-            val imm = activity?.getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager
-            imm.hideSoftInputFromWindow(requireView().windowToken, 0)
+            val keyboard = activity?.getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager
+            keyboard.hideSoftInputFromWindow(requireView().windowToken, 0)
             authenticateUser()
         }
         binding.btnToRegistration.setOnClickListener {

--- a/app/src/main/java/com/example/internapp/authentication/RegistrationFragment.kt
+++ b/app/src/main/java/com/example/internapp/authentication/RegistrationFragment.kt
@@ -13,7 +13,9 @@ import com.example.internapp.R
 import com.example.internapp.databinding.RegistrationFragmentBinding
 import com.example.internapp.repository.UIState
 import com.google.android.material.snackbar.Snackbar
+import dagger.hilt.android.AndroidEntryPoint
 
+@AndroidEntryPoint
 class RegistrationFragment : Fragment() {
     private val viewModel: AuthenticationViewModel by activityViewModels()
     private lateinit var binding: RegistrationFragmentBinding
@@ -29,6 +31,7 @@ class RegistrationFragment : Fragment() {
             val imm = context?.getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager
             imm.hideSoftInputFromWindow(requireView().windowToken, 0)
         }
+        viewModel.setUIState(UIState.OnWaiting)
         initStateObserver()
         return binding.root
     }
@@ -53,6 +56,15 @@ class RegistrationFragment : Fragment() {
                 Snackbar.LENGTH_SHORT
             ).show()
             return
+        }else{
+            if(password.length<6){
+                Snackbar.make(
+                    requireView(),
+                    resources.getString(R.string.requiredPasswordSize),
+                    Snackbar.LENGTH_SHORT
+                ).show()
+                return
+            }
         }
         if (password == passwordRepeat) {
             viewModel.createUser(email, password)
@@ -75,6 +87,9 @@ class RegistrationFragment : Fragment() {
                 }
                 UIState.InProgress -> {
                     binding.pbRegistration.visibility = View.VISIBLE
+                }
+                UIState.OnWaiting -> {
+                    binding.pbRegistration.visibility = View.GONE
                 }
                 UIState.OnError -> {
                     binding.pbRegistration.visibility = View.GONE

--- a/app/src/main/java/com/example/internapp/repository/MarvelApiService.kt
+++ b/app/src/main/java/com/example/internapp/repository/MarvelApiService.kt
@@ -10,7 +10,7 @@ interface MarvelApiService {
         @Query("ts") timestamp: String,
         @Query("apikey") apiKey: String,
         @Query("hash") hash: String,
-        @Query("sharedAppearances") title: String?,
+        @Query("titleStartsWith") title: String?,
         @Query("limit") limit: Int?
     ): Response<ComicProperty>
 }

--- a/app/src/main/java/com/example/internapp/repository/MarvelApiService.kt
+++ b/app/src/main/java/com/example/internapp/repository/MarvelApiService.kt
@@ -10,7 +10,7 @@ interface MarvelApiService {
         @Query("ts") timestamp: String,
         @Query("apikey") apiKey: String,
         @Query("hash") hash: String,
-        @Query("titleStartsWith") title: String?,
+        @Query("sharedAppearances") title: String?,
         @Query("limit") limit: Int?
     ): Response<ComicProperty>
 }

--- a/app/src/main/java/com/example/internapp/repository/MarvelModule.kt
+++ b/app/src/main/java/com/example/internapp/repository/MarvelModule.kt
@@ -10,29 +10,42 @@ import dagger.hilt.android.components.ActivityRetainedComponent
 import okhttp3.OkHttpClient
 import retrofit2.Retrofit
 import retrofit2.converter.moshi.MoshiConverterFactory
-import javax.inject.Singleton
 
 @Module
 @InstallIn(ActivityRetainedComponent::class)
 object MarvelModule {
-    private const val BASE_URL = "https://gateway.marvel.com/"
-    private val builder = OkHttpClient.Builder()
-        .connectTimeout(20, java.util.concurrent.TimeUnit.SECONDS)
-        .writeTimeout(30, java.util.concurrent.TimeUnit.SECONDS)
-        .readTimeout(30, java.util.concurrent.TimeUnit.SECONDS)
-    private val client = builder.build()
-
-    private val moshi = Moshi.Builder()
-        .add(KotlinJsonAdapterFactory())
-        .build()
-
-    private val retrofit = Retrofit.Builder()
-        .baseUrl(BASE_URL)
-        .addConverterFactory(MoshiConverterFactory.create(moshi))
-        .addCallAdapterFactory(CoroutineCallAdapterFactory())
-        .client(client)
-        .build()
 
     @Provides
-    fun provideMarvelApiService(): MarvelApiService = retrofit.create(MarvelApiService::class.java)
+    fun provideBaseUrl(): String {
+        return "https://gateway.marvel.com/"
+    }
+
+    @Provides
+    fun provideClient(): OkHttpClient {
+        return OkHttpClient.Builder()
+            .connectTimeout(20, java.util.concurrent.TimeUnit.SECONDS)
+            .writeTimeout(30, java.util.concurrent.TimeUnit.SECONDS)
+            .readTimeout(30, java.util.concurrent.TimeUnit.SECONDS).build()
+    }
+
+    @Provides
+    fun provideMoshi(): Moshi {
+        return Moshi.Builder()
+            .add(KotlinJsonAdapterFactory())
+            .build()
+    }
+
+    @Provides
+    fun provideRetrofit(BASE_URL: String, moshi: Moshi, client: OkHttpClient): Retrofit {
+        return Retrofit.Builder()
+            .baseUrl(BASE_URL)
+            .addConverterFactory(MoshiConverterFactory.create(moshi))
+            .addCallAdapterFactory(CoroutineCallAdapterFactory())
+            .client(client)
+            .build()
+    }
+
+    @Provides
+    fun provideMarvelApiService(retrofit: Retrofit): MarvelApiService =
+        retrofit.create(MarvelApiService::class.java)
 }

--- a/app/src/main/java/com/example/internapp/ui/DetailFragment.kt
+++ b/app/src/main/java/com/example/internapp/ui/DetailFragment.kt
@@ -11,8 +11,6 @@ import androidx.fragment.app.activityViewModels
 import com.example.internapp.MainViewModel
 import com.example.internapp.databinding.DetailFragmentBinding
 import com.google.android.material.bottomsheet.BottomSheetBehavior
-import com.google.android.material.bottomsheet.BottomSheetDialog
-import com.google.android.material.bottomsheet.BottomSheetDialogFragment
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint

--- a/app/src/main/java/com/example/internapp/ui/SplashFragment.kt
+++ b/app/src/main/java/com/example/internapp/ui/SplashFragment.kt
@@ -33,7 +33,7 @@ class SplashFragment : Fragment() {
         super.onStart()
         Handler().postDelayed({
             viewModel.isUserLoggedIn()
-        }, 1000)
+        }, 3000)
     }
 
     override fun onResume() {

--- a/app/src/main/res/layout/login_fragment.xml
+++ b/app/src/main/res/layout/login_fragment.xml
@@ -35,8 +35,7 @@
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
                 android:ems="15"
-                android:inputType="text"
-                android:text="@string/primitiveEmail" />
+                android:inputType="text" />
         </com.google.android.material.textfield.TextInputLayout>
 
         <com.google.android.material.textfield.TextInputLayout
@@ -56,8 +55,7 @@
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
                 android:ems="15"
-                android:inputType="textPassword"
-                android:text="@string/primitivePassword" />
+                android:inputType="textPassword" />
         </com.google.android.material.textfield.TextInputLayout>
 
         <Button
@@ -86,8 +84,8 @@
             android:layout_width="100dp"
             android:layout_height="100dp"
             android:theme="@style/ProgressBarStyle"
-            android:visibility="gone"
             android:translationZ="90dp"
+            android:visibility="gone"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"

--- a/app/src/main/res/layout/registration_fragment.xml
+++ b/app/src/main/res/layout/registration_fragment.xml
@@ -55,7 +55,7 @@
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
                 android:ems="15"
-                android:inputType="textVisiblePassword"/>
+                android:inputType="textPassword"/>
         </com.google.android.material.textfield.TextInputLayout>
 
         <com.google.android.material.textfield.TextInputLayout

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -13,13 +13,12 @@
     <string name="written_by">written by</string>
     <string name="find_out_more">Find out more</string>
     <!-- TODO: Remove or change this placeholder text -->
-    <string name="hello_blank_fragment">Hello blank fragment</string>
     <string name="textLoginTitle">Zaloguj się</string>
-    <string name="textHintLogin">Type Login or Email</string>
-    <string name="textHintPassword">Type password</string>
+    <string name="textHintLogin">Type Email</string>
+    <string name="textHintPassword">Type Password</string>
     <string name="textLogIn">Zaloguj się</string>
     <string name="textRegistration">Zarejestruj się</string>
-    <string name="textHintPasswordRepeat">Repeat password</string>
+    <string name="textHintPasswordRepeat">Repeat Password</string>
     <string name="textSignUp">Zarejestruj się</string>
     <string name="textRegistrationTitle">Załóż konto</string>
     <string name="passwordDifference">Wprowadzone hasła nie są zgodne!</string>
@@ -33,5 +32,8 @@
     <string name="profile">Profil</string>
     <string name="welcome">Witaj "%s" :)</string>
     <string name="pressAgain">Wciśnij ponownie aby wyjść.</string>
+    <string name="noEmail">Podaj adres email.</string>
+    <string name="noPassword">Podaj hasło.</string>
+    <string name="requiredPasswordSize">Hasło wymaga minimum 6 znaków.</string>
 
 </resources>


### PR DESCRIPTION
Hide keyboard after LoginButton pressed.
Checking is login and password empty.
Clear UIStete.OnError after navigate to Registration or to Fragment.
Empty email / password inputs.
Add string resources.
Rebuild MarvelModule with @Provides.